### PR TITLE
Fix dark mode initialization race blocking Google sign-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -1655,7 +1655,7 @@
         // Flyout elements
         let flyoutBackdrop, flyoutPanel, flyoutTitle, flyoutClose, flyoutContent;
         // Authentication elements
-        let googleSignInBtn, loginError, loginScreen, appContainer;
+        let googleSignInBtn, loginError, loginScreen, appContainer, googleSignInBtnDefaultHTML;
 
         // --- STATE ---
         let fullData = [];
@@ -2869,10 +2869,10 @@
         function applyDarkMode() {
             if (isDarkMode) {
                 document.documentElement.classList.add('dark');
-                darkModeToggle.textContent = '☀️';
+                if (darkModeToggle) darkModeToggle.textContent = '☀️';
             } else {
                 document.documentElement.classList.remove('dark');
-                darkModeToggle.textContent = '🌙';
+                if (darkModeToggle) darkModeToggle.textContent = '🌙';
             }
         }
 
@@ -2963,9 +2963,6 @@
         });
 
         async function initializeApp() {
-            // Apply theme
-            applyTheme();
-            
             // Initialize DOM elements
             loader = document.getElementById('loader');
             errorMessage = document.getElementById('errorMessage');
@@ -2999,6 +2996,10 @@
             loginError = document.getElementById('loginError');
             loginScreen = document.getElementById('loginScreen');
             appContainer = document.getElementById('appContainer');
+            googleSignInBtnDefaultHTML = googleSignInBtn.innerHTML;
+
+            // Apply theme after elements are ready
+            applyTheme();
 
             // Set up event listeners
             setupEventListeners();
@@ -3083,6 +3084,10 @@
             }
 
             // Google sign-in
+            function resetGoogleSignInButton() {
+                googleSignInBtn.disabled = false;
+                googleSignInBtn.innerHTML = googleSignInBtnDefaultHTML;
+            }
             googleSignInBtn.addEventListener('click', function() {
                 if (!auth || !provider) {
                     if (loginError) {
@@ -3102,6 +3107,7 @@
                                 loginError.textContent = 'Please sign in with your ' + ORGANISATION_DOMAIN + ' email.';
                                 loginError.classList.remove('hidden');
                             }
+                            resetGoogleSignInButton();
                         }
                     })
                     .catch((error) => {
@@ -3110,8 +3116,7 @@
                             loginError.textContent = error.message;
                             loginError.classList.remove('hidden');
                         }
-                        googleSignInBtn.disabled = false;
-                        googleSignInBtn.innerHTML = '<img class="google-icon w-5 h-5 mr-3" src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="" aria-hidden="true" />Sign in with Google';
+                        resetGoogleSignInButton();
                     });
             });
 


### PR DESCRIPTION
## Summary
- Guard dark mode toggle updates if the element isn't yet on the page
- Initialize DOM elements before applying theme so sign-in and dark mode load correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b59fb2a5408324bf93f779779f3b1d